### PR TITLE
Improve TOC Active Highlighting

### DIFF
--- a/src/components/ui/TableOfContents.astro
+++ b/src/components/ui/TableOfContents.astro
@@ -40,13 +40,15 @@ const { toc = [] }: TOCProps = Astro.props
       window.__tocController.destroy()
     }
 
-    const activeOffset = 96
+    const activeOffset = 128
+    const jumpOffset = 96
 
     // Core state
     const state = {
       container: null,
       linkList: [],
       headingList: [],
+      headingHeight: null,
       titleLink: null,
       headingMap: new Map(),
       headingObserver: null,
@@ -66,6 +68,11 @@ const { toc = [] }: TOCProps = Astro.props
       state.headingList = Array.from(document.querySelectorAll('h1, h2, h3')).filter(
         (heading, index, headings) => !(index === 0 && headings[0].tagName === 'H1') && heading.id
       )
+
+      if (state.headingList[0]) {
+        state.headingHeight = state.headingList[0].getBoundingClientRect().height
+      }
+
       state.titleLink = document.querySelector('.toc-link.toc-title')
 
       // Build heading map
@@ -134,7 +141,7 @@ const { toc = [] }: TOCProps = Astro.props
           if (target) {
             const rect = target.getBoundingClientRect()
             const scrollTop = window.pageYOffset || document.documentElement.scrollTop
-            const offset = rect.top + scrollTop - activeOffset
+            const offset = rect.top + scrollTop - jumpOffset
             window.scrollTo({ top: offset, behavior: 'smooth' })
             history.pushState(null, null, href)
           }
@@ -173,7 +180,7 @@ const { toc = [] }: TOCProps = Astro.props
       }
 
       state.headingObserver = new IntersectionObserver(refreshActiveHeading, {
-        rootMargin: `-${activeOffset}px 0px -65% 0px`,
+        rootMargin: `-${activeOffset}px 0px 0px 0px`,
         threshold: 0
       })
 
@@ -186,13 +193,13 @@ const { toc = [] }: TOCProps = Astro.props
         return
       }
 
-      if (window.pageYOffset < 16 || state.headingList[0].getBoundingClientRect().top > activeOffset) {
+      if (window.pageYOffset < 16 || state.headingList[0].getBoundingClientRect().top > (activeOffset - state.headingHeight)) {
         setActive(null)
         return
       }
 
       for (let i = state.headingList.length - 1; i >= 0; i--) {
-        if (state.headingList[i].getBoundingClientRect().top <= activeOffset) {
+        if (state.headingList[i].getBoundingClientRect().top <= (activeOffset - state.headingHeight)) {
           setActive(state.headingList[i].id)
           break
         }


### PR DESCRIPTION
I've made the following changes
* Separated the `activeOffset` and `jumpOffset` variables to enable fine tuning between when the TOC highlighting activates and where the clicking the link would jump to
* Added code to get the height of the headings
* Adjusted active heading calculation

These changes have corrected the following issues
* Fixed an issue where the next heading above wouldn't be correctly selected after scrolling up
* Made the trigger area align with the index button
* Fixed an edge case where clicking on a link would incorrectly highlight the wrong heading after jumping to it