### PR TITLE
chore(deps): add cooldown and pin pnpm 11.21.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     cooldown:
-      default-days: 2
+      default-days: 7
     assignees:
       - 'the3ash'
     commit-message:
@@ -69,7 +69,7 @@ updates:
       interval: 'weekly'
       day: 'monday'
     cooldown:
-      default-days: 2
+      default-days: 7
     assignees:
       - 'the3ash'
     commit-message:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6.0.10
-        with:
-          version: latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "1.0.0",
   "license": "MIT",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "dev": "tsx scripts/update-link-metadata.ts && astro dev",
     "build": "pnpm run typecheck && tsx scripts/update-link-metadata.ts && astro build",


### PR DESCRIPTION
## What changed

- Set `cooldown.default-days` to 7 for npm and GitHub Actions version updates.
- Pin the project package manager to `pnpm@11.21.0` in `package.json`.
- Remove `version: latest` from `pnpm/action-setup` so CI reads the project-level version declaration.

## Why

The cooldown avoids adopting dependency releases during their first week. Pinning pnpm prevents CI behavior from changing whenever a new pnpm release is published and keeps local and CI package-manager selection aligned.

Dependabot security updates are not delayed by `cooldown`.

## Checks

- Parsed `package.json` and confirmed `packageManager` is `pnpm@11.21.0`.
- Parsed `.github/workflows/ci.yml` successfully.
- Parsed `.github/dependabot.yml` and verified both update entries use `default-days: 7`.
- Ran `git diff --check`.
